### PR TITLE
feat: enable file content and switch to qwen3-coder in ai-review work…

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           debug: true
           base_url: "https://openrouter.ai/api/v1"
-          use_file_content: false
+          use_file_content: true
           summary_model: |
-            openrouter/deepseek/deepseek-chat-v3-0324:free
+            openrouter/qwen/qwen3-coder:free
           model: |
-            openrouter/deepseek/deepseek-chat-v3-0324:free
+            openrouter/qwen/qwen3-coder:free
           file_type_prompts: |
             javascript: |
               Focus on ES6+ best practices and modern JavaScript patterns.


### PR DESCRIPTION

- Enable use_file_content: true in .github/workflows/ai-review.yml
- Update summary_model from openrouter/deepseek/deepseek-chat-v3-0324:free to openrouter/qwen/qwen3-coder:free
- Update model from openrouter/deepseek/deepseek-chat-v3-0324:free to openrouter/qwen/qwen3-coder:free
<!-- This is an auto-generated comment: release notes -->
### Key Changes:
- Chore: AIレビュー用のGitHub Actionsワークフロー設定を更新  
  - `use_file_content`設定をfalseからtrueに変更  
  - 使用するAIモデルをDeepSeekからQwenのコーダー向けモデルに統一  

（注: この変更は内部プロセスの改善であり、エンドユーザーへの直接的な影響はありません）
<!-- end of auto-generated comment: release notes -->